### PR TITLE
Fix the broken easter egg on mobile browsers

### DIFF
--- a/src/components/PageBottomAnimation/index.jsx
+++ b/src/components/PageBottomAnimation/index.jsx
@@ -5,17 +5,19 @@ import { createPortal } from 'preact/compat';
 import { initTurtleAnimation, getPageContentWidth } from './turtle-animation'
 import './PageBottomAnimation.scss'
 
-const PAGE_EXTENSION_DELAY = 1000
+const PAGE_EXTENSION_DELAY = 750
 const PAGE_EXTENSION_MAX_COUNT = 7
 
 // helper method
 const isPageFullyScrolled = () => {
-  // reference: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled
   const rootHtml = document.documentElement
   const isPageScrollable = rootHtml.scrollHeight - rootHtml.clientHeight > 1
+  const totalHeight = rootHtml.scrollHeight
+  const scrollTop = window.scrollY || rootHtml.scrollTop
+  const viewportHeight = window.innerHeight
 
   return isPageScrollable
-    ? Math.abs(rootHtml.scrollHeight - rootHtml.clientHeight - rootHtml.scrollTop) < 2
+    ? totalHeight - (scrollTop + viewportHeight) < 2
     : true
 }
 


### PR DESCRIPTION
Fix the issue https://gitlab.okturtles.org/okturtles/shelterprotocol-net/-/issues/13

The key change here is to replace `rootHtml.clientHeight` with `window.innerHeight`.
It works fine on my mobile Brave and Chrome.


https://github.com/user-attachments/assets/4e611208-fee7-4198-b097-67d943efe839
